### PR TITLE
Renew SAS key for the sample images

### DIFF
--- a/batchai/setup.md
+++ b/batchai/setup.md
@@ -70,7 +70,7 @@ With the commands below, we will create an Azure File Share to hold setup and jo
 ```
 az storage share create --account-name %STORAGE_ACCOUNT_NAME% --name batchai
 az storage container create --account-name %STORAGE_ACCOUNT_NAME% --name blobfuse
-AzCopy /Source:https://aiforearthcollateral.blob.core.windows.net/imagesegmentationtutorial /SourceSAS:"?st=2018-01-16T10%3A40%3A00Z&se=2028-01-17T10%3A40%3A00Z&sp=rl&sv=2017-04-17&sr=c&sig=KeEzmTaFvVo2ptu2GZQqv5mJ8saaPpeNRNPoasRS0RE%3D" /Dest:https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/blobfuse /DestKey:%STORAGE_ACCOUNT_KEY% /S
+AzCopy /Source:https://aiforearthcollateral.blob.core.windows.net/imagesegmentationtutorial /SourceSAS:"https://aiforearthcollateral.blob.core.windows.net/imagesegmentationtutorial?st=2018-11-27T08%3A06%3A25Z&se=2019-11-28T08%3A06%3A00Z&sp=rl&sv=2018-03-28&sr=c&sig=Y8z35PmqGtCWNJzXvbod%2FJPeqtvnEmhIF8EQn4uuO44%3D" /Dest:https://%STORAGE_ACCOUNT_NAME%.blob.core.windows.net/blobfuse /DestKey:%STORAGE_ACCOUNT_KEY% /S
 ```
 
 Expect the copy step to take 5-10 minutes.


### PR DESCRIPTION
Renewed the SAS key required to access the blob `imagesegmentationtutorial` on `aiforearthcollateral` to 2019/11/27.